### PR TITLE
ci(pubsub): add gh workflow jobs for Horizon core components

### DIFF
--- a/.github/workflows/pubsub-horizon.yml
+++ b/.github/workflows/pubsub-horizon.yml
@@ -13,15 +13,92 @@ permissions:
   id-token: write
 
 jobs:
+  # Horizon Core Runtime Components:
+  #
+  # Horizon Starlight
+  build-pubsub-horizon-starlight:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-starlight'
+      source_dockerfile: 'Dockerfile.multi-stage'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-starlight'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # Horizon Galaxy
+  build-pubsub-horizon-galaxy:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-galaxy'
+      source_dockerfile: 'Dockerfile.multi-stage'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-galaxy'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # Horizon Comet
+  build-pubsub-horizon-comet:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-comet'
+      source_dockerfile: 'Dockerfile.multi-stage'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-comet'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # Horizon Pulsar
+  build-pubsub-horizon-pulsar:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-pulsar'
+      source_dockerfile: 'Dockerfile.multi-stage'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-pulsar'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # Horizon Golaris
+  build-pubsub-horizon-golaris:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-golaris'
+      source_dockerfile: 'Dockerfile'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-golaris'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # Horizon Vortex
+  build-pubsub-horizon-vortex:
+    uses: ./.github/workflows/_fetch_build_push_image.yml
+    with:
+      source_repository: 'telekom/pubsub-horizon-vortex'
+      source_dockerfile: 'Dockerfile'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-vortex'
+      target_architecture: 'linux/amd64'
+      target_registry: 'ghcr.io'
+      target_registry_username: ${{ github.actor }}
+    secrets:
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+  #
+  # Horizon Tools:
+  #
+  # Horizon Cosmoparrot
   build-pubsub-horizon-cosmoparrot:
     uses: ./.github/workflows/_fetch_build_push_image.yml
     with:
       source_repository: 'telekom/pubsub-horizon-cosmoparrot'
-      source_branch: 'wip'
       source_dockerfile: 'Dockerfile'
       target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/pubsub-horizon-cosmoparrot'
       target_architecture: 'linux/amd64'
       target_registry: 'ghcr.io'
       target_registry_username: ${{ github.actor }}
     secrets:
-      target_registry_password: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_password: ${{ secrets.GITHUB_TOKEN }}  


### PR DESCRIPTION
Extended the existing workflow for building images for all Horizon (Pub/Sub) related runtime components