### PR TITLE
doc: refer new gateway-issuer-service-go in github workflow

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       source_repository: 'telekom/gateway-issuer-service'
       source_dockerfile: 'Dockerfile.multi-stage'
-      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/gateway-issuer-service'
+      target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/gateway-issuer-service-go'
       target_architecture: 'linux/amd64'
       target_registry: 'ghcr.io'
       target_registry_username: ${{ github.actor }}

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -28,7 +28,7 @@ jobs:
   build-gateway-issuer-service:
     uses: ./.github/workflows/_fetch_build_push_image.yml
     with:
-      source_repository: 'telekom/gateway-issuer-service'
+      source_repository: 'telekom/gateway-issuer-service-go'
       source_dockerfile: 'Dockerfile.multi-stage'
       target_image: 'ghcr.io/${{ github.repository_owner }}/o28m/gateway-issuer-service-go'
       target_architecture: 'linux/amd64'

--- a/build/README.md
+++ b/build/README.md
@@ -23,7 +23,7 @@ The workflows are bundled per component and can be found in the `.github/workflo
   - [x] Identity-Iris-Keycloak (A modified Keycloak image)
 - [x] [Gateway](../.github/workflows/gateway.yml):
   - [x] Gateway-Jumper (A sidecar container for the Gateway)
-  - [x] Gateway-Issuer-Service (A sidecar container for the Gateway)
+  - [x] Gateway-Issuer-Service-Go (A sidecar container for the Gateway)
   - [x] Gateway-Kong (A modified Kong image with several plugins and compatible with all Postgres versions >= 13, also 14+)
 - [x] [Helper Images](../.github/workflows/helpers.yml):
   - [x] Bash-Curl (A helper image with pre-installed bash and curl to bootstrap and configure the Gateway)


### PR DESCRIPTION
Reference to use new go based gateway-issuer-service as replacement for gateway-issuer-service