### PR TITLE
fix(img): fix visual svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC0-1.0
 # Open Telekom Integration Platform
 
 <p align="center">
-    <img src="img/Open-Telekom-Integration-Platform_Visual.svg" alt="Visual" width="200">
+    <img src="img/Open-Telekom-Integration-Platform_Visual.svg" alt="Visual" width="200" height="200"/>
 </p>
 
 ## About

--- a/img/Open-Telekom-Integration-Platform_Visual.svg
+++ b/img/Open-Telekom-Integration-Platform_Visual.svg
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    width="100%"


### PR DESCRIPTION
I noticed that the visual in the `README .md` didn't render properly. This PR addresses this issue.

<details>
<img src="https://github.com/user-attachments/assets/0ef28a89-9e33-4406-9e18-476dc27ac2c1"/>
<summary>This is what it looks like at the moment</summary>
</details>