### PR TITLE
fix(helpers): upgrade helper image bases + repin postgres off frozen bitnamilegacy

### DIFF
--- a/.github/workflows/helpers.yml
+++ b/.github/workflows/helpers.yml
@@ -19,7 +19,7 @@ jobs:
       source_repository: "${{ github.repository }}"
       source_dockerfile: "build/helpers/Dockerfile.bash-curl"
       source_build_args: |
-        BASH_CURL_VERSION=8.13.0
+        BASH_CURL_VERSION=8.20.0
       target_image: "ghcr.io/${{ github.repository_owner }}/o28m/bash-curl"
       target_architecture: "linux/amd64, linux/arm64"
       target_registry: "ghcr.io"
@@ -33,7 +33,7 @@ jobs:
       source_repository: "${{ github.repository }}"
       source_dockerfile: "build/helpers/Dockerfile.haproxy"
       source_build_args: |
-        HAPROXY_VERSION=3.1.6-alpine
+        HAPROXY_VERSION=3.2.10-alpine
       target_image: "ghcr.io/${{ github.repository_owner }}/o28m/haproxy"
       target_architecture: "linux/amd64, linux/arm64"
       target_registry: "ghcr.io"
@@ -47,7 +47,7 @@ jobs:
       source_repository: "${{ github.repository }}"
       source_dockerfile: "build/helpers/Dockerfile.postgresql"
       source_build_args: |
-        POSTGRES_VERSION=16.5.0
+        POSTGRESQL_VERSION=17.10-trixie
       target_image: "ghcr.io/${{ github.repository_owner }}/o28m/postgresql"
       target_architecture: "linux/amd64, linux/arm64"
       target_registry: "ghcr.io"

--- a/build/helpers/Dockerfile.bash-curl
+++ b/build/helpers/Dockerfile.bash-curl
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASH_CURL_VERSION=8.13.0
+ARG BASH_CURL_VERSION=8.20.0
 FROM quay.io/curl/curl-base:${BASH_CURL_VERSION}
 
 RUN apk add --no-cache bash jq

--- a/build/helpers/Dockerfile.haproxy
+++ b/build/helpers/Dockerfile.haproxy
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG HAPROXY_VERSION=3.1.6-alpine
+ARG HAPROXY_VERSION=3.2.10-alpine
 FROM haproxy:${HAPROXY_VERSION}

--- a/build/helpers/Dockerfile.postgresql
+++ b/build/helpers/Dockerfile.postgresql
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG POSTGRESQL_VERSION=16.5.0
-FROM bitnami/postgresql:${POSTGRESQL_VERSION}
+ARG POSTGRESQL_VERSION=17.10-trixie
+FROM postgres:${POSTGRESQL_VERSION}


### PR DESCRIPTION
Bumps the three helper image bases to current maintained versions.

| Helper | Before | After |
|---|---|---|
| bash-curl | `curl-base:8.13.0` | `8.20.0` |
| haproxy | `3.1.6-alpine` | `3.2.10-alpine` (LTS) |
| postgresql | `bitnami/postgresql:16.5.0` | official `postgres:17.10-trixie` |

`bitnami/postgresql:16.5.0` was removed from Docker Hub (now only in the frozen `bitnamilegacy` org), so the postgres helper is repinned to the maintained official image — a drop-in, since the charts already use official `POSTGRES_*`/`PGDATA` conventions. Also fixes the `helpers.yml` postgres build-arg name (`POSTGRES_VERSION` → `POSTGRESQL_VERSION`).

Note: postgres 16→17 is a major bump (existing local-DB volumes need migration; prod uses an external DB). Consuming charts need a matching `17.10-trixie` tag bump (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
